### PR TITLE
texture: dest_size no longer mandatory if source is set

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -124,11 +124,10 @@ pub fn draw_texture_ex(
         h: texture.height(),
     });
 
-    let (w, h) = params
-        .dest_size
-        .map_or((texture.width(), texture.height()), |dst| {
-            (dst.x(), dst.y())
-        });
+    let (w, h) = match params.dest_size {
+        Some(dst) => (dst.x(), dst.y()),
+        _ => (sw, sh),
+    };
 
     let pivot = params.pivot.unwrap_or(vec2(x + w / 2., y + h / 2.));
     let m = pivot;


### PR DESCRIPTION
Use "source" part of texture sizes for target size.

DrawTextureParams {
   source: Some(Rect::new(0.0,0.0,16.0,32.0)),
   ..Default::default()
});

Before this change a quad of *texture.width(), texture.height()) size would be drawn.
After - always sized (16, 32).